### PR TITLE
Issue & comment 관련 API 구현

### DIFF
--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -8,6 +8,8 @@ const {
   closeIssue,
   createAssignee,
   deleteAssignee,
+  createMilestone,
+  deleteMilestone,
 } = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
@@ -127,10 +129,29 @@ module.exports = {
 
   deleteAssignee: (req, res) => {
     deleteAssignee(req.body, (err, results) => {
-      const failMessage = '요청하신 이슈의 담당자 삭제를 실패했습니다.';
-
       if (err) {
-        return res.status(400).json(failResponse(failMessage));
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  createMilestone: (req, res) => {
+    createMilestone(req.body, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  deleteMilestone: (req, res) => {
+    const issueId = req.body.issueId;
+    deleteMilestone(issueId, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
       }
 
       return res.status(200).json(successResponse(results));

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -74,6 +74,7 @@ module.exports = {
 
   updateIssue: (req, res) => {
     req.body.id = req.params.issue_id;
+
     updateIssue(req.body, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
@@ -113,6 +114,7 @@ module.exports = {
 
   updateIssue: (req, res) => {
     req.body.id = req.params.issue_id;
+
     updateIssue(req.body, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
@@ -156,6 +158,7 @@ module.exports = {
 
   deleteMilestone: (req, res) => {
     const issueId = req.body.issueId;
+
     deleteMilestone(issueId, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
@@ -181,6 +184,34 @@ module.exports = {
     deleteLabel(req.body, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  getComments: (req, res) => {
+    const issueId = req.params.issue_id;
+
+    getComments(issueId, (err, results) => {
+      const failMessage = '요청하신 이슈의 comment가 존재하지 않습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  getCommentsCount: (req, res) => {
+    const issueId = req.params.issue_id;
+
+    getCommentsCount(issueId, (err, results) => {
+      const failMessage = '요청하신 이슈가 존재하지 않습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
       }
 
       return res.status(200).json(successResponse(results));

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -6,6 +6,8 @@ const {
   updateIssue,
   openIssue,
   closeIssue,
+  createAssignee,
+  deleteAssignee,
 } = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
@@ -91,6 +93,41 @@ module.exports = {
 
     closeIssue(issueId, (err, results) => {
       const failMessage = '이슈를 closed 하는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  updateIssue: (req, res) => {
+    req.body.id = req.params.issue_id;
+    updateIssue(req.body, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  createAssignee: (req, res) => {
+    createAssignee(req.body, (err, results) => {
+      const failMessage = '요청하신 이슈의 담당자 지정을 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  deleteAssignee: (req, res) => {
+    deleteAssignee(req.body, (err, results) => {
+      const failMessage = '요청하신 이슈의 담당자 삭제를 실패했습니다.';
 
       if (err) {
         return res.status(400).json(failResponse(failMessage));

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -187,12 +187,6 @@ module.exports = {
     });
   },
 
-  // getComments,
-  // getCommentsCount,
-  // createComment,
-  // updateComment,
-  // deleteComment,
-
   createComment: (req, res) => {
     createComment(req.body, (err, results) => {
       const failMessage = '이슈의 comment를 생성하는데 실패했습니다.';

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -1,10 +1,25 @@
-const { getAllIssues } = require('./issue.service');
+const { getAllIssues, getIssuesByAuthor } = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
 module.exports = {
   getAllIssues: (req, res) => {
     getAllIssues(req.body, (err, results) => {
       const failMessage = '이슈 목록을 불러오는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  getIssuesByAuthor: (req, res) => {
+    const userId = req.params.userId;
+
+    getIssuesByAuthor(userId, (err, results) => {
+      const failMessage =
+        '요청하신 사용자가 만든 이슈 목록을 불러오는데 실패했습니다.';
 
       if (err) {
         return res.status(400).json(failResponse(failMessage));

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -1,10 +1,18 @@
-const { getAllIssues, getIssuesByAuthor } = require('./issue.service');
+const {
+  getAllOpenIssues,
+  getAllCloseIssues,
+  getIssue,
+  createIssue,
+  updateIssue,
+  openIssue,
+  closeIssue,
+} = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
 module.exports = {
-  getAllIssues: (req, res) => {
-    getAllIssues(req.body, (err, results) => {
-      const failMessage = '이슈 목록을 불러오는데 실패했습니다.';
+  getAllOpenIssues: (req, res) => {
+    getAllOpenIssues(req.body, (err, results) => {
+      const failMessage = 'open된 이슈 목록을 불러오는데 실패했습니다.';
 
       if (err) {
         return res.status(400).json(failResponse(failMessage));
@@ -14,12 +22,75 @@ module.exports = {
     });
   },
 
-  getIssuesByAuthor: (req, res) => {
-    const userId = req.params.userId;
+  getAllCloseIssues: (req, res) => {
+    getAllCloseIssues(req.body, (err, results) => {
+      const failMessage = 'closed된 이슈 목록을 불러오는데 실패했습니다.';
 
-    getIssuesByAuthor(userId, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  getIssue: (req, res) => {
+    const issueId = req.params.issue_id;
+
+    getIssue(issueId, (err, results) => {
       const failMessage =
         '요청하신 사용자가 만든 이슈 목록을 불러오는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  createIssue: (req, res) => {
+    createIssue(req.body, (err, results) => {
+      const failMessage = '이슈를 생성하는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  updateIssue: (req, res) => {
+    req.body.id = req.params.issue_id;
+    updateIssue(req.body, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  openIssue: (req, res) => {
+    const issueId = req.params.issue_id;
+
+    openIssue(issueId, (err, results) => {
+      const failMessage = '이슈를 open 하는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  closeIssue: (req, res) => {
+    const issueId = req.params.issue_id;
+
+    closeIssue(issueId, (err, results) => {
+      const failMessage = '이슈를 closed 하는데 실패했습니다.';
 
       if (err) {
         return res.status(400).json(failResponse(failMessage));

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -10,6 +10,8 @@ const {
   deleteAssignee,
   createMilestone,
   deleteMilestone,
+  createLabel,
+  deleteLabel,
 } = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
@@ -150,6 +152,28 @@ module.exports = {
   deleteMilestone: (req, res) => {
     const issueId = req.body.issueId;
     deleteMilestone(issueId, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  createLabel: (req, res) => {
+    createLabel(req.body, (err, results) => {
+      const failMessage = '요청하신 이슈의 label 지정을 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  deleteLabel: (req, res) => {
+    deleteLabel(req.body, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
       }

--- a/Server/api/issue/issue.controller.js
+++ b/Server/api/issue/issue.controller.js
@@ -12,6 +12,11 @@ const {
   deleteMilestone,
   createLabel,
   deleteLabel,
+  getComments,
+  getCommentsCount,
+  createComment,
+  updateComment,
+  deleteComment,
 } = require('./issue.service');
 const { failResponse, successResponse } = require('../utils/returnForm');
 
@@ -174,6 +179,44 @@ module.exports = {
 
   deleteLabel: (req, res) => {
     deleteLabel(req.body, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  // getComments,
+  // getCommentsCount,
+  // createComment,
+  // updateComment,
+  // deleteComment,
+
+  createComment: (req, res) => {
+    createComment(req.body, (err, results) => {
+      const failMessage = '이슈의 comment를 생성하는데 실패했습니다.';
+
+      if (err) {
+        return res.status(400).json(failResponse(failMessage));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  updateComment: (req, res) => {
+    updateComment(req.body, (err, results) => {
+      if (err) {
+        return res.status(400).json(failResponse(err));
+      }
+
+      return res.status(200).json(successResponse(results));
+    });
+  },
+
+  deleteComment: (req, res) => {
+    deleteComment(req.body, (err, results) => {
       if (err) {
         return res.status(400).json(failResponse(err));
       }

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -1,6 +1,7 @@
-const { getAllIssues } = require('./issue.controller');
+const { getAllIssues, getIssuesByAuthor } = require('./issue.controller');
 const router = require('express').Router();
 
 router.post('/', getAllIssues);
+router.get('/:userId', getIssuesByAuthor);
 
 module.exports = router;

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -10,6 +10,8 @@ const {
   deleteAssignee,
   createMilestone,
   deleteMilestone,
+  createLabel,
+  deleteLabel,
 } = require('./issue.controller');
 const router = require('express').Router();
 
@@ -22,14 +24,13 @@ router.post('/open/:issue_id', openIssue);
 router.post('/close/:issue_id', closeIssue);
 router.post('/assignee', createAssignee);
 router.post('/milestone', createMilestone);
+router.post('/label', createLabel);
 
 router.put('/:issue_id', updateIssue);
 
 router.delete('/assignee', deleteAssignee);
 router.delete('/milestone', deleteMilestone);
-
-// 이슈 라벨 생성
-// 이슈 라벨 삭제
+router.delete('/label', deleteLabel);
 
 // 이슈에 댓글 달면, 그에 맞는 코멘트 생성
 // 이슈의 코멘트 개수 반환

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -8,27 +8,28 @@ const {
   closeIssue,
   createAssignee,
   deleteAssignee,
+  createMilestone,
+  deleteMilestone,
 } = require('./issue.controller');
 const router = require('express').Router();
 
-router.get('/open', getAllOpenIssues); // open된 전체 이슈 조회
-router.get('/closed', getAllCloseIssues); // closed된 전체 이슈 조회
-router.get('/:issue_id', getIssue); // 특정 이슈 조회
+router.get('/open', getAllOpenIssues);
+router.get('/closed', getAllCloseIssues);
+router.get('/:issue_id', getIssue);
 
-router.post('/', createIssue); // 이슈 생성
-router.post('/open/:issue_id', openIssue); // 이슈 open
-router.post('/close/:issue_id', closeIssue); // 이슈 close
-router.post('/assignee', createAssignee); // 이슈 담당자 생성
+router.post('/', createIssue);
+router.post('/open/:issue_id', openIssue);
+router.post('/close/:issue_id', closeIssue);
+router.post('/assignee', createAssignee);
+router.post('/milestone', createMilestone);
 
-router.put('/:issue_id', updateIssue); // 이슈 수정
+router.put('/:issue_id', updateIssue);
 
-router.delete('/assignee', deleteAssignee); // 이슈 담당자 삭제
+router.delete('/assignee', deleteAssignee);
+router.delete('/milestone', deleteMilestone);
 
 // 이슈 라벨 생성
 // 이슈 라벨 삭제
-
-// 이슈 마일스톤 생성
-// 이슈 마일스톤 삭제
 
 // 이슈에 댓글 달면, 그에 맞는 코멘트 생성
 // 이슈의 코멘트 개수 반환

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -12,6 +12,11 @@ const {
   deleteMilestone,
   createLabel,
   deleteLabel,
+  getComments,
+  getCommentsCount,
+  createComment,
+  updateComment,
+  deleteComment,
 } = require('./issue.controller');
 const router = require('express').Router();
 
@@ -32,7 +37,11 @@ router.delete('/assignee', deleteAssignee);
 router.delete('/milestone', deleteMilestone);
 router.delete('/label', deleteLabel);
 
-// 이슈에 댓글 달면, 그에 맞는 코멘트 생성
-// 이슈의 코멘트 개수 반환
+// issue의 comment 관련
+// router.get('/comment/:issue_id', getComments);
+// router.get('/comment/count/:issue_id', getCommentsCount);
+router.post('/comment', createComment);
+router.post('/comment/update', updateComment);
+router.delete('/comment', deleteComment);
 
 module.exports = router;

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -38,10 +38,12 @@ router.delete('/milestone', deleteMilestone);
 router.delete('/label', deleteLabel);
 
 // issue의 comment 관련
-// router.get('/comment/:issue_id', getComments);
-// router.get('/comment/count/:issue_id', getCommentsCount);
+router.get('/comment/:issue_id', getComments);
+router.get('/comment/count/:issue_id', getCommentsCount);
+
 router.post('/comment', createComment);
 router.post('/comment/update', updateComment);
+
 router.delete('/comment', deleteComment);
 
 module.exports = router;

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -6,6 +6,8 @@ const {
   updateIssue,
   openIssue,
   closeIssue,
+  createAssignee,
+  deleteAssignee,
 } = require('./issue.controller');
 const router = require('express').Router();
 
@@ -14,10 +16,21 @@ router.get('/closed', getAllCloseIssues); // closed된 전체 이슈 조회
 router.get('/:issue_id', getIssue); // 특정 이슈 조회
 
 router.post('/', createIssue); // 이슈 생성
-
-router.patch('/:issue_id', updateIssue); // 이슈 수정
-
 router.post('/open/:issue_id', openIssue); // 이슈 open
 router.post('/close/:issue_id', closeIssue); // 이슈 close
+router.post('/assignee', createAssignee); // 이슈 담당자 생성
+
+router.put('/:issue_id', updateIssue); // 이슈 수정
+
+router.delete('/assignee', deleteAssignee); // 이슈 담당자 삭제
+
+// 이슈 라벨 생성
+// 이슈 라벨 삭제
+
+// 이슈 마일스톤 생성
+// 이슈 마일스톤 삭제
+
+// 이슈에 댓글 달면, 그에 맞는 코멘트 생성
+// 이슈의 코멘트 개수 반환
 
 module.exports = router;

--- a/Server/api/issue/issue.router.js
+++ b/Server/api/issue/issue.router.js
@@ -1,7 +1,23 @@
-const { getAllIssues, getIssuesByAuthor } = require('./issue.controller');
+const {
+  getAllOpenIssues,
+  getAllCloseIssues,
+  getIssue,
+  createIssue,
+  updateIssue,
+  openIssue,
+  closeIssue,
+} = require('./issue.controller');
 const router = require('express').Router();
 
-router.post('/', getAllIssues);
-router.get('/:userId', getIssuesByAuthor);
+router.get('/open', getAllOpenIssues); // open된 전체 이슈 조회
+router.get('/closed', getAllCloseIssues); // closed된 전체 이슈 조회
+router.get('/:issue_id', getIssue); // 특정 이슈 조회
+
+router.post('/', createIssue); // 이슈 생성
+
+router.patch('/:issue_id', updateIssue); // 이슈 수정
+
+router.post('/open/:issue_id', openIssue); // 이슈 open
+router.post('/close/:issue_id', closeIssue); // 이슈 close
 
 module.exports = router;

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -153,4 +153,32 @@ module.exports = {
 
     return callBack(results.data);
   },
+
+  createLabel: async (req, callBack) => {
+    const { issueId, labelId } = req;
+    const params = [issueId, labelId];
+    const results = await requestQuery(query.CREATE_LABEL_FOR_ISSUE, params);
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 label 지정이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  deleteLabel: async (req, callBack) => {
+    const { issueId, labelId } = req;
+    const params = [issueId, labelId];
+    const results = await requestQuery(query.DELETE_LABEL_FOR_ISSUE, params);
+
+    if (results.data[0].affectedRows == 0) {
+      return callBack('삭제를 요청하신 이슈가 존재하지 않습니다.');
+    }
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 label 삭제가 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
 };

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -181,4 +181,51 @@ module.exports = {
 
     return callBack(results.data);
   },
+
+  createComment: async (req, callBack) => {
+    const { userId, issueId, content } = req;
+    const params = [userId, issueId, content];
+    const results = await requestQuery(query.CREATE_COMMENT, params);
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 comment 생성이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  updateComment: async (req, callBack) => {
+    const { userId, issueId, content, commentId } = req;
+    const params = [userId, issueId, content, commentId];
+    const updatedItem = await requestQuery(query.UPDATE_COMMENT, params);
+
+    if (updatedItem.data[0].affectedRows == 0) {
+      return callBack('수정을 요청하신 컬럼이 존재하지 않습니다.');
+    }
+
+    const results = {
+      userId,
+      issueId,
+      content,
+      commentId,
+    };
+
+    return callBack(null, results);
+  },
+
+  deleteComment: async (req, callBack) => {
+    const { commentId } = req;
+    const params = [commentId];
+    const results = await requestQuery(query.DELETE_COMMENT, params);
+
+    if (results.data[0].affectedRows == 0) {
+      return callBack('삭제를 요청하신 이슈가 존재하지 않습니다.');
+    }
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 comment 삭제가 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
 };

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -11,4 +11,18 @@ module.exports = {
 
     return callBack(results.data);
   },
+
+  getIssuesByAuthor: async (userId, callBack) => {
+    const results = await requestQuery(query.GET_ISSUES_BY_AUTHOR, [userId]);
+
+    if (results.status === 'success') {
+      if (results.data[0].length === 0) {
+        return callBack(results.data);
+      }
+
+      return callBack(null, results.data[0]);
+    }
+
+    return callBack(results.data);
+  },
 };

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -8,6 +8,7 @@ module.exports = {
 
     if (results.status === 'success') {
       const issueList = await makeIssueTemplate(results);
+
       return callBack(null, issueList);
     }
 
@@ -19,6 +20,7 @@ module.exports = {
 
     if (results.status === 'success') {
       const issueList = await makeIssueTemplate(results);
+
       return callBack(null, issueList);
     }
 
@@ -34,6 +36,7 @@ module.exports = {
       }
 
       const issueList = await makeIssueTemplate(results);
+
       return callBack(null, issueList);
     }
 

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -182,6 +182,30 @@ module.exports = {
     return callBack(results.data);
   },
 
+  getComments: async (issueId, callBack) => {
+    const results = await requestQuery(query.GET_COMMENTS, [issueId]);
+
+    if (results.status === 'success') {
+      if (results.data[0].length === 0) {
+        return callBack(results.data);
+      }
+
+      return callBack(null, results.data[0]);
+    }
+
+    return callBack(results.data[0]);
+  },
+
+  getCommentsCount: async (issueId, callBack) => {
+    const results = await requestQuery(query.GET_COMMENTS_COUNT, [issueId]);
+
+    if (results.status === 'success') {
+      return callBack(null, results.data[0]);
+    }
+
+    return callBack(results.data[0]);
+  },
+
   createComment: async (req, callBack) => {
     const { userId, issueId, content } = req;
     const params = [userId, issueId, content];

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -90,4 +90,28 @@ module.exports = {
 
     return callBack(results.data);
   },
+
+  createAssignee: async (req, callBack) => {
+    const { userId, issueId } = req;
+    const params = [userId, issueId];
+    const results = await requestQuery(query.CREATE_ASSIGNEE_FOR_ISSUE, params);
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 담당자 생성이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  deleteAssignee: async (req, callBack) => {
+    const { userId, issueId } = req;
+    const params = [userId, issueId];
+    const results = await requestQuery(query.DELETE_ASSIGNEE_FOR_ISSUE, params);
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 담당자 삭제가 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
 };

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -1,26 +1,91 @@
 const { requestQuery } = require('../../config/database');
+const { makeIssueTemplate } = require('./issue.template');
 const query = require('../utils/issue.query');
 
 module.exports = {
-  getAllIssues: async (req, callBack) => {
-    const results = await requestQuery(query.GET_ISSUES);
+  getAllOpenIssues: async (req, callBack) => {
+    const results = await requestQuery(query.GET_OPEN_ISSUES);
 
     if (results.status === 'success') {
-      return callBack(null, results.data[0]);
+      const issueList = await makeIssueTemplate(results);
+      return callBack(null, issueList);
     }
 
     return callBack(results.data);
   },
 
-  getIssuesByAuthor: async (userId, callBack) => {
-    const results = await requestQuery(query.GET_ISSUES_BY_AUTHOR, [userId]);
+  getAllCloseIssues: async (req, callBack) => {
+    const results = await requestQuery(query.GET_CLOSE_ISSUES);
+
+    if (results.status === 'success') {
+      const issueList = await makeIssueTemplate(results);
+      return callBack(null, issueList);
+    }
+
+    return callBack(results.data);
+  },
+
+  getIssue: async (issueId, callBack) => {
+    const results = await requestQuery(query.GET_ISSUE, [issueId]);
 
     if (results.status === 'success') {
       if (results.data[0].length === 0) {
         return callBack(results.data);
       }
 
-      return callBack(null, results.data[0]);
+      const issueList = await makeIssueTemplate(results);
+      return callBack(null, issueList);
+    }
+
+    return callBack(results.data[0]);
+  },
+
+  createIssue: async (req, callBack) => {
+    const { userId, milestoneId, title, content } = req;
+    const params = [userId, milestoneId, title, content];
+    const results = await requestQuery(query.CREATE_ISSUE, params);
+
+    if (results.status === 'success') {
+      return callBack(null, '이슈 생성이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  updateIssue: async (req, callBack) => {
+    const { userId, milestoneId, title, content, id } = req;
+    const params = [userId, milestoneId, title, content, id];
+    const updatedItem = await requestQuery(query.UPDATE_ISSUE, params);
+
+    if (updatedItem.data[0].affectedRows == 0) {
+      return callBack('수정을 요청하신 컬럼이 존재하지 않습니다.');
+    }
+
+    const results = {
+      userId,
+      milestoneId,
+      title,
+      content,
+    };
+
+    return callBack(null, results);
+  },
+
+  openIssue: async (issueId, callBack) => {
+    const results = await requestQuery(query.OPEN_ISSUE, [issueId]);
+
+    if (results.status === 'success') {
+      return callBack(null, '이슈 open이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  closeIssue: async (issueId, callBack) => {
+    const results = await requestQuery(query.CLOSE_ISSUE, [issueId]);
+
+    if (results.status === 'success') {
+      return callBack(null, '이슈 closed가 완료되었습니다.');
     }
 
     return callBack(results.data);

--- a/Server/api/issue/issue.service.js
+++ b/Server/api/issue/issue.service.js
@@ -97,7 +97,7 @@ module.exports = {
     const results = await requestQuery(query.CREATE_ASSIGNEE_FOR_ISSUE, params);
 
     if (results.status === 'success') {
-      return callBack(null, '요청하신 이슈의 담당자 생성이 완료되었습니다.');
+      return callBack(null, '요청하신 이슈의 담당자 지정이 완료되었습니다.');
     }
 
     return callBack(results.data);
@@ -107,6 +107,45 @@ module.exports = {
     const { userId, issueId } = req;
     const params = [userId, issueId];
     const results = await requestQuery(query.DELETE_ASSIGNEE_FOR_ISSUE, params);
+
+    if (results.data[0].affectedRows == 0) {
+      return callBack('삭제를 요청하신 이슈가 존재하지 않습니다.');
+    }
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 담당자 삭제가 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  createMilestone: async (req, callBack) => {
+    const { milestoneId, issueId } = req;
+    const params = [milestoneId, issueId];
+    const results = await requestQuery(
+      query.CREATE_MILESTONE_FOR_ISSUE,
+      params
+    );
+
+    if (results.data[0].affectedRows == 0) {
+      return callBack('수정을 요청하신 이슈가 존재하지 않습니다.');
+    }
+
+    if (results.status === 'success') {
+      return callBack(null, '요청하신 이슈의 마일스톤 지정이 완료되었습니다.');
+    }
+
+    return callBack(results.data);
+  },
+
+  deleteMilestone: async (issueId, callBack) => {
+    const results = await requestQuery(query.DELETE_MILESTONE_FOR_ISSUE, [
+      issueId,
+    ]);
+
+    if (results.data[0].affectedRows == 0) {
+      return callBack('수정을 요청하신 이슈가 존재하지 않습니다.');
+    }
 
     if (results.status === 'success') {
       return callBack(null, '요청하신 이슈의 담당자 삭제가 완료되었습니다.');

--- a/Server/api/issue/issue.template.js
+++ b/Server/api/issue/issue.template.js
@@ -13,8 +13,8 @@ module.exports = {
         query.GET_ASSIGNEES_BY_ISSUE_ID,
         [issue.issueId]
       );
-
       const assigneeList = [];
+
       for (let assign of assigneeResults.data[0]) {
         assigneeList.push(assign.name);
       }

--- a/Server/api/issue/issue.template.js
+++ b/Server/api/issue/issue.template.js
@@ -1,0 +1,28 @@
+const { requestQuery } = require('../../config/database');
+const query = require('../utils/issue.query');
+
+module.exports = {
+  makeIssueTemplate: async (results) => {
+    const issueList = [...results.data[0]];
+
+    for (let issue of issueList) {
+      const labelList = await requestQuery(query.GET_LABELS_BY_ISSUE_ID, [
+        issue.issueId,
+      ]);
+      const assigneeResults = await requestQuery(
+        query.GET_ASSIGNEES_BY_ISSUE_ID,
+        [issue.issueId]
+      );
+
+      const assigneeList = [];
+      for (let assign of assigneeResults.data[0]) {
+        assigneeList.push(assign.name);
+      }
+
+      issue.label = labelList.data[0];
+      issue.assign = assigneeList;
+    }
+
+    return issueList;
+  },
+};

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -1,6 +1,8 @@
 const query = {
   GET_ISSUES:
-    'SELECT id, userId, milestoneId, title, content, isOpen, createAt, closeAt  from issue',
+    'SELECT issue.id, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, milestone.title as milestoneTitle, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue join milestone on issue.milestoneID = milestone.id',
+  GET_ISSUES_BY_AUTHOR:
+    'SELECT issue.id, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, milestone.title as milestoneTitle, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue join milestone on issue.milestoneID = milestone.id WHERE issue.userID = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -1,8 +1,21 @@
+// get, create, update, delete
 const query = {
-  GET_ISSUES:
-    'SELECT issue.id, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, milestone.title as milestoneTitle, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue join milestone on issue.milestoneID = milestone.id',
-  GET_ISSUES_BY_AUTHOR:
-    'SELECT issue.id, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, milestone.title as milestoneTitle, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue join milestone on issue.milestoneID = milestone.id WHERE issue.userID = ?',
+  GET_OPEN_ISSUES:
+    'SELECT issue.id as issueId, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, (SELECT milestone.title FROM milestone WHERE issue.milestoneID = milestone.id) as milestone, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue WHERE issue.isOpen = 1',
+  GET_CLOSE_ISSUES:
+    'SELECT issue.id as issueId, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, (SELECT milestone.title FROM milestone WHERE issue.milestoneID = milestone.id) as milestone, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue WHERE issue.isOpen = 0',
+  GET_ISSUE:
+    'SELECT issue.id as issueId, (SELECT user.email FROM user WHERE user.id = issue.userId) as email, (SELECT user.name FROM user WHERE user.id = issue.userId) as name, (SELECT milestone.title FROM milestone WHERE issue.milestoneID = milestone.id) as milestone, issue.title, issue.content, issue.isOpen, issue.createAt, issue.closeAt FROM issue WHERE issue.id = ?',
+  GET_LABELS_BY_ISSUE_ID:
+    'SELECT (SELECT label.name FROM label WHERE label.id = issue_label.labelId) as labelName, (SELECT label.color FROM label WHERE label.id = issue_label.labelId) as labelColor, (SELECT label.description FROM label WHERE label.id = issue_label.labelId) as labelDescription FROM issue JOIN issue_label ON issue.id = issue_label.issueId WHERE issue_label.issueId = ?',
+  GET_ASSIGNEES_BY_ISSUE_ID:
+    'SELECT (SELECT user.name FROM user WHERE user.id = issue_assignee.userId) as name FROM issue JOIN issue_assignee ON issue.id = issue_assignee.issueId WHERE issue_assignee.issueId = ?',
+  CREATE_ISSUE:
+    'INSERT INTO issue (userId, milestoneId, title, content) VALUES(?, ?, ?, ?)',
+  UPDATE_ISSUE:
+    'UPDATE issue SET userId = ?, milestoneId = ?, title = ?, content = ? WHERE id = ?',
+  OPEN_ISSUE: 'UPDATE issue SET isOpen = 1 WHERE id = ?',
+  CLOSE_ISSUE: 'UPDATE issue SET isOpen = 0 WHERE id = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -27,6 +27,11 @@ const query = {
     'INSERT INTO issue_label (issueId, labelId) VALUES(?, ?)',
   DELETE_LABEL_FOR_ISSUE:
     'DELETE FROM issue_label WHERE issueId = ? and labelId = ?',
+  CREATE_COMMENT:
+    'INSERT INTO comment (userId, issueId, content) VALUES(?, ?, ?)',
+  UPDATE_COMMENT:
+    'UPDATE comment SET userId = ?, issueId = ?, content = ? WHERE id = ?',
+  DELETE_COMMENT: 'DELETE FROM comment WHERE id = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -20,6 +20,9 @@ const query = {
     'INSERT INTO issue_assignee (userId, issueId) VALUES(?, ?)',
   DELETE_ASSIGNEE_FOR_ISSUE:
     'DELETE FROM issue_assignee WHERE userId = ? and issueId = ?',
+  CREATE_MILESTONE_FOR_ISSUE: 'UPDATE issue SET milestoneId = ? WHERE id = ?',
+  DELETE_MILESTONE_FOR_ISSUE:
+    'UPDATE issue SET milestoneId = NULL WHERE id = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -16,6 +16,10 @@ const query = {
     'UPDATE issue SET userId = ?, milestoneId = ?, title = ?, content = ? WHERE id = ?',
   OPEN_ISSUE: 'UPDATE issue SET isOpen = 1 WHERE id = ?',
   CLOSE_ISSUE: 'UPDATE issue SET isOpen = 0 WHERE id = ?',
+  CREATE_ASSIGNEE_FOR_ISSUE:
+    'INSERT INTO issue_assignee (userId, issueId) VALUES(?, ?)',
+  DELETE_ASSIGNEE_FOR_ISSUE:
+    'DELETE FROM issue_assignee WHERE userId = ? and issueId = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -23,6 +23,10 @@ const query = {
   CREATE_MILESTONE_FOR_ISSUE: 'UPDATE issue SET milestoneId = ? WHERE id = ?',
   DELETE_MILESTONE_FOR_ISSUE:
     'UPDATE issue SET milestoneId = NULL WHERE id = ?',
+  CREATE_LABEL_FOR_ISSUE:
+    'INSERT INTO issue_label (issueId, labelId) VALUES(?, ?)',
+  DELETE_LABEL_FOR_ISSUE:
+    'DELETE FROM issue_label WHERE issueId = ? and labelId = ?',
 };
 
 module.exports = query;

--- a/Server/api/utils/issue.query.js
+++ b/Server/api/utils/issue.query.js
@@ -32,6 +32,10 @@ const query = {
   UPDATE_COMMENT:
     'UPDATE comment SET userId = ?, issueId = ?, content = ? WHERE id = ?',
   DELETE_COMMENT: 'DELETE FROM comment WHERE id = ?',
+  GET_COMMENTS:
+    'SELECT comment.id as commentId, (SELECT user.name FROM user WHERE user.id = comment.userId) as name, comment.content, comment.createAt FROM comment WHERE comment.issueId = ?',
+  GET_COMMENTS_COUNT:
+    'SELECT count(*) as commentCount FROM comment where issueId = ?',
 };
 
 module.exports = query;


### PR DESCRIPTION
<br/>

### 각 API 관련 요청 uri & 반환되는 json 내용은 <br/>이슈번호를 클릭하시면 확인하실 수 있습니다.

<br/>

[이슈]
#22 목록 조회: 로그인한 사용자와 관련있는 issue를 모두 반환하는 API를 개발
- [x] 전체 이슈 조회 => open된 이슈 / closed된 이슈로 나뉘어져 있음
- [x] 세부 이슈 조회
<br/>

#25 issue open 여부 변경
- [x] 사용자가 체크박스로 선택한 issue list의 open 여부를 일괄 업데이트하는 API를 개발
   - 여러 개를 동시에 open 하도록 map 형태로 req.body를 받아버리면,
      만약 일부는 open 성공하고, 일부는 open 실패했을 때 결과를 리턴하기 애매함
   - 원래는 한 요청 당 한 query를 수행하는 게 맞으므로 이 이슈는 42번 이슈에서 생성한 API를 사용하면 될 듯하다.
   - <b>결론: open Issue를 여러번 돌리면 될 듯! (42번 이슈로 대체 가능해보여서 추가로 구현 X)</b>
<br/>

#42 이슈 클로즈 및 오픈: 
- [x] 클로즈하면 0(false) - 이슈 삭제의 느낌이 close
- [x] 오픈하면 1(true)로 바꿔주기
<br/>

#39 Issues 저장(생성)
- [x] 이슈 생성
<br/>

#40 이슈 수정
- [x]  이슈 내용 업데이트 요청
<br/>

#43 Assignee 수정
- [x] 이슈 담당자 생성
- [x] 이슈 담당자 삭제
<br/>

#44 Labels 수정
- [x] 이슈 라벨 생성
- [x] 이슈 라벨 삭제
<br/>

#45 Milestone 수정
- [x] 이슈 마일스톤 생성
- [x] 이슈 마일스톤 삭제
<br/>

#41 코멘트 생성 요청 (상세 이슈 보기 클릭 시 필요)
- [x] 이슈에 댓글 달면, 그에 맞는 코멘트 생성
<br/>

#46 이슈의 코멘트 개수 반환
- [x] 이슈의 코멘트 개수 반환
<br/>

#91 이슈의 코멘트 조회/수정/삭제
- [x] 이슈의 코멘트 조회/수정/삭제
