### PR TITLE
Feat : useContext와 useReducer를 이용한 Label 목록 관리

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -4,6 +4,7 @@
   "description": "Issue tracker 08 team client project",
   "main": "index.js",
   "scripts": {
+    "start": "webpack-dev-server --hot --host 0.0.0.0",
     "dev": "webpack-dev-server --progress --mode development",
     "build": "webpack --progress --mode production",
     "test": "test"

--- a/Client/src/components/label/Label.jsx
+++ b/Client/src/components/label/Label.jsx
@@ -7,10 +7,11 @@ const Container = styled.div`
   background-color: ${(props) => props.background};
   color: ${(props) => props.color};
   height: 20px;
+  font-size: 12px;
   font-weight: bold;
   text-align: center;
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: 10px;
 `;
 
 const Label = (props) => {

--- a/Client/src/components/label/LabelContainer.jsx
+++ b/Client/src/components/label/LabelContainer.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import Label from './Label';
 
+import { DELETE_LABELS } from '../../utils/api';
+import { deleteOptions } from '../../utils/fetchOptions';
+
 const Container = styled.div`
   display: flex;
   align-items: center;
@@ -25,19 +28,29 @@ const Text = styled.p`
   color: #91979d;
 `;
 
-const LabelContainer = (props) => {
+const LabelContainer = ({ id, name, color, description }) => {
+  const deleteLabelRequest = () => {
+    const options = deleteOptions;
+    fetch(DELETE_LABELS(id), options);
+  };
+
+  const deleteLabel = (e) => {
+    if (confirm(`${name}을 정말로 삭제하시겠습니까?`)) {
+      deleteLabelRequest();
+    }
+  };
   return (
     <Container>
       <FlexContainer flex="1">
-        <Label name={props.name} color={props.color} />
+        <Label name={name} color={color} />
       </FlexContainer>
       <FlexContainer flex="3">
-        <Text>{props.description}</Text>
+        <Text>{description}</Text>
       </FlexContainer>
       <Button>
         <Text>Edit</Text>
       </Button>
-      <Button>
+      <Button onClick={deleteLabel}>
         <Text>Delete</Text>
       </Button>
     </Container>

--- a/Client/src/components/label/LabelContainer.jsx
+++ b/Client/src/components/label/LabelContainer.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import Label from './Label';
 
+import { LabelContext } from '../../stores/LabelStore';
 import { DELETE_LABELS } from '../../utils/api';
 import { deleteOptions } from '../../utils/fetchOptions';
 
@@ -29,6 +30,7 @@ const Text = styled.p`
 `;
 
 const LabelContainer = ({ id, name, color, description }) => {
+  const { dispatch } = useContext(LabelContext);
   const deleteLabelRequest = () => {
     const options = deleteOptions;
     fetch(DELETE_LABELS(id), options);
@@ -37,6 +39,7 @@ const LabelContainer = ({ id, name, color, description }) => {
   const deleteLabel = (e) => {
     if (confirm(`${name}을 정말로 삭제하시겠습니까?`)) {
       deleteLabelRequest();
+      dispatch({ type: 'DELETE_LABEL', payload: id });
     }
   };
   return (

--- a/Client/src/components/label/LabelList.jsx
+++ b/Client/src/components/label/LabelList.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+import LabelContainer from './LabelContainer';
+
+const LabelList = ({ labels, loading }) => {
+  let labelList = <div>Loading...</div>;
+  if (!loading) {
+    labelList = labels.map((label) => (
+      <LabelContainer
+        key={label.id}
+        name={label.name}
+        color={label.color}
+        description={label.description}
+      />
+    ));
+  }
+  return <>{labelList}</>;
+};
+
+export default LabelList;

--- a/Client/src/components/label/LabelList.jsx
+++ b/Client/src/components/label/LabelList.jsx
@@ -8,6 +8,7 @@ const LabelList = ({ labels, loading }) => {
     labelList = labels.map((label) => (
       <LabelContainer
         key={label.id}
+        id={label.id}
         name={label.name}
         color={label.color}
         description={label.description}

--- a/Client/src/components/label/LabelList.jsx
+++ b/Client/src/components/label/LabelList.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useContext } from 'react';
 import LabelContainer from './LabelContainer';
+import { LabelContext } from '../../stores/LabelStore';
 
-const LabelList = ({ labels, loading }) => {
+const LabelList = () => {
+  const { labels, loading } = useContext(LabelContext);
   let labelList = <div>Loading...</div>;
   if (!loading) {
     labelList = labels.map((label) => (

--- a/Client/src/components/label/LabelTitle.jsx
+++ b/Client/src/components/label/LabelTitle.jsx
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import Title from '../shared/text/Title';
+import { LabelContext } from '../../stores/LabelStore';
+
+const LabelTitle = () => {
+  const { labels } = useContext(LabelContext);
+  return (
+    <>
+      <Title text={labels.length + ' labels'} />
+    </>
+  );
+};
+
+export default LabelTitle;

--- a/Client/src/hooks/useFetch.js
+++ b/Client/src/hooks/useFetch.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+const useFetch = (callback, url, options) => {
+  const [loading, setLoading] = useState(false);
+
+  const fetchInitialData = async () => {
+    setLoading(true);
+    const response = await fetch(url, options);
+    const initialData = await response.json();
+    callback(initialData.data);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchInitialData();
+  }, []);
+
+  return loading;
+};
+
+export default useFetch;

--- a/Client/src/pages/label/LabelPage.jsx
+++ b/Client/src/pages/label/LabelPage.jsx
@@ -1,29 +1,24 @@
 import React, { useState } from 'react';
+import LabelStore from '../../stores/LabelStore';
 import Container from '../../components/shared/container/Container';
 import ItemContainer from '../../components/shared/container/ItemContainer';
 import ItemHeader from '../../components/shared/container/ItemHeader';
-import Title from '../../components/shared/text/Title';
+import LabelTitle from '../../components/label/LabelTitle';
 import Menu from '../../components/shared/container/Menu';
 import LabelList from '../../components/label/LabelList';
-import useFetch from '../../hooks/useFetch';
-
-import { GET_LABELS } from '../../utils/api';
-import { getOptions } from '../../utils/fetchOptions';
 
 export default function LabelPage() {
-  const [labels, setLabels] = useState([]);
-
-  const loading = useFetch(setLabels, GET_LABELS, getOptions);
-
   return (
-    <Container>
-      <Menu name="label" link="/label"></Menu>
-      <ItemContainer>
-        <ItemHeader>
-          <Title text={labels.length + ' labels'} />
-        </ItemHeader>
-        <LabelList labels={labels} loading={loading} />
-      </ItemContainer>
-    </Container>
+    <LabelStore>
+      <Container>
+        <Menu name="label" link="/label"></Menu>
+        <ItemContainer>
+          <ItemHeader>
+            <LabelTitle />
+          </ItemHeader>
+          <LabelList />
+        </ItemContainer>
+      </Container>
+    </LabelStore>
   );
 }

--- a/Client/src/pages/label/LabelPage.jsx
+++ b/Client/src/pages/label/LabelPage.jsx
@@ -1,24 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Container from '../../components/shared/container/Container';
 import ItemContainer from '../../components/shared/container/ItemContainer';
 import ItemHeader from '../../components/shared/container/ItemHeader';
 import Title from '../../components/shared/text/Title';
 import Menu from '../../components/shared/container/Menu';
-import LabelContainer from '../../components/label/LabelContainer';
+import LabelList from '../../components/label/LabelList';
+import useFetch from '../../hooks/useFetch';
+
+import { GET_LABELS } from '../../utils/api';
+import { getOptions } from '../../utils/fetchOptions';
 
 export default function LabelPage() {
+  const [labels, setLabels] = useState([]);
+
+  const loading = useFetch(setLabels, GET_LABELS, getOptions);
+
   return (
     <Container>
       <Menu name="label" link="/label"></Menu>
       <ItemContainer>
         <ItemHeader>
-          <Title text={'labels'} />
+          <Title text={labels.length + ' labels'} />
         </ItemHeader>
-        <LabelContainer
-          name="라벨 이름"
-          color="#123456"
-          description="라벨 설명"
-        ></LabelContainer>
+        <LabelList labels={labels} loading={loading} />
       </ItemContainer>
     </Container>
   );

--- a/Client/src/reducers/labelReducer.js
+++ b/Client/src/reducers/labelReducer.js
@@ -3,6 +3,9 @@ export const labelReducer = (labels, { type, payload }) => {
     case 'SET_INIT_DATA':
       return payload;
 
+    case 'DELETE_LABEL':
+      return labels.filter((label) => label.id !== payload);
+
     default:
       break;
   }

--- a/Client/src/reducers/labelReducer.js
+++ b/Client/src/reducers/labelReducer.js
@@ -1,0 +1,9 @@
+export const labelReducer = (labels, { type, payload }) => {
+  switch (type) {
+    case 'SET_INIT_DATA':
+      return payload;
+
+    default:
+      break;
+  }
+};

--- a/Client/src/stores/LabelStore.js
+++ b/Client/src/stores/LabelStore.js
@@ -1,0 +1,29 @@
+import React, { useReducer, useEffect } from 'react';
+import useFetch from '../hooks/useFetch';
+import { GET_LABELS } from '../utils/api';
+import { getOptions } from '../utils/fetchOptions';
+import { labelReducer } from '../reducers/labelReducer';
+
+export const LabelContext = React.createContext();
+
+const LabelStore = (props) => {
+  const [labels, dispatch] = useReducer(labelReducer, []);
+
+  const setIntiData = (initData) => {
+    dispatch({ type: 'SET_INIT_DATA', payload: initData });
+  };
+
+  const loading = useFetch(setIntiData, GET_LABELS, getOptions);
+
+  useEffect(() => {
+    console.log('새로운 내용이 렌더링됐네요', labels);
+  }, [labels]);
+
+  return (
+    <LabelContext.Provider value={{ labels, loading, dispatch }}>
+      {props.children}
+    </LabelContext.Provider>
+  );
+};
+
+export default LabelStore;

--- a/Client/src/stores/LabelStore.js
+++ b/Client/src/stores/LabelStore.js
@@ -15,10 +15,6 @@ const LabelStore = (props) => {
 
   const loading = useFetch(setIntiData, GET_LABELS, getOptions);
 
-  useEffect(() => {
-    console.log('새로운 내용이 렌더링됐네요', labels);
-  }, [labels]);
-
   return (
     <LabelContext.Provider value={{ labels, loading, dispatch }}>
       {props.children}

--- a/Client/src/utils/api.js
+++ b/Client/src/utils/api.js
@@ -3,3 +3,5 @@ import * as config from '../config';
 export const POST_ISSUE = config.BASE_URL + 'api/issues';
 
 export const GET_LABELS = config.BASE_URL + 'api/labels';
+
+export const DELETE_LABELS = (id) => config.BASE_URL + 'api/labels/' + id;

--- a/Client/src/utils/api.js
+++ b/Client/src/utils/api.js
@@ -1,3 +1,5 @@
 import * as config from '../config';
 
 export const POST_ISSUE = config.BASE_URL + 'api/issues';
+
+export const GET_LABELS = config.BASE_URL + 'api/labels';


### PR DESCRIPTION
### 📕 Issue Number

Close #215 #216 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] #215 전체 Lables 목록
- 전체 레이블 목록 표시
    ㄴ 레이블 목록 상단에 전체 레이블 개수 표시
    ㄴ 반복문으로 레이블 불러오기

- [x] # 216 Delete 버튼 구현
- 화면에서 동적으로 제거해주기
- 전체 Lables 목록에 위치한 Delete 버튼 클릭 시, 
   확인 메시지 (정말 삭제하실 것인지?) confirm 창 팝업
- [확인] 클릭 시 : 레이블 삭제 진행
- [취소] 클릭 시 : 레이블 삭제 취소

<br/>

### 📗 새로운 기능

- Label 조회
- Label 삭제
  <br/>

### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 리펙토링
      <br/>

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- useContext와 useReducer를 활용한 LabelStore를 만들어서 관리하였습니다.

<br/><br/>
